### PR TITLE
Laravel 5.4 compatibility

### DIFF
--- a/src/TunnelerServiceProvider.php
+++ b/src/TunnelerServiceProvider.php
@@ -43,7 +43,7 @@ class TunnelerServiceProvider extends ServiceProvider{
         }
         $this->mergeConfigFrom($this->configPath, 'tunneler');
 
-        $this->app['command.tunneler.activate'] = $this->app->share(
+        $this->app->singleton('command.tunneler.activate',
             function ($app) {
                 return new TunnelerCommand();
             }


### PR DESCRIPTION
https://laravel.com/docs/5.4/upgrade

share Method Removed

The share method has been removed from the container. This was a legacy method that has not been documented in several years. If you are using this method, you should begin using the singleton method instead:

$container->singleton('foo', function () {
    return 'foo';
});