### PR TITLE
Added env variable to increase the amount of connection checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ TUNNELER_PORT=sshport
 ; Depending on your network speeds you will want to modify the default of .5 seconds
 TUNNELER_CONN_WAIT=500000
 
+; How often it is checked if the tunnel is created. Useful if the tunnel creation is sometimes slow, 
+; and you want to minimize waiting times 
+TUNNELER_CONN_TRIES=1
+
 ; Do you want to ensure you have the Tunnel in place for each bootstrap of the framework?
 TUNNELER_ON_BOOT=false
 

--- a/config/tunneler.php
+++ b/config/tunneler.php
@@ -19,6 +19,7 @@ return [
     'hostname' => env('TUNNELER_HOSTNAME'),
     'port' => env('TUNNELER_PORT'),
     'wait' => env('TUNNELER_CONN_WAIT', '500000'),
+    'tries' => env('TUNNELER_CONN_TRIES', 1),
 
     'on_boot' => filter_var(env('TUNNELER_ON_BOOT', false), FILTER_VALIDATE_BOOLEAN),
     'ssh_verbosity' => env('SSH_VERBOSITY',''),

--- a/src/Jobs/CreateTunnel.php
+++ b/src/Jobs/CreateTunnel.php
@@ -58,9 +58,12 @@ class CreateTunnel
         }
 
         $this->createTunnel();
-
-        if ($this->verifyTunnel()) {
-            return 2;
+        
+        $tries = config('tunneler.tries');
+        for ($i = 0; $i < $tries; $i++) {
+            if ($this->verifyTunnel()) {
+                return 2;
+            }
         }
 
         throw new \ErrorException(sprintf("Could Not Create SSH Tunnel with command:\n\t%s\nCheck your configuration.",

--- a/src/Jobs/CreateTunnel.php
+++ b/src/Jobs/CreateTunnel.php
@@ -64,6 +64,9 @@ class CreateTunnel
             if ($this->verifyTunnel()) {
                 return 2;
             }
+            
+            // Wait a bit until next iteration
+            usleep(config('tunneler.wait'));
         }
 
         throw new \ErrorException(sprintf("Could Not Create SSH Tunnel with command:\n\t%s\nCheck your configuration.",


### PR DESCRIPTION
The creation of tunnel connections varies between 1 to 10 seconds on our dev servers. This means that the tunneler declares a connection failure on short wait times (even though it just took longer than expected). Configuring longer wait times (like 10 seconds for example) seems pretty inefficient to me. 

My solution is a simple loop which runs the configured amount of times. This leads to short waiting times while still supporting long connection creation times. 