### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,17 @@ We do not support version <=5.1.
 composer require stechstudio/laravel-ssh-tunnel
 ```
 
-### Register the Provider:
+### Register the Provider (Laravel version 5.8):
+
+Inside the `config/app.php` file under `Package Service Providers`, add:
+
+```STS\Tunneler\TunnelerServiceProvider::class,```
+
+And under `Application Service Providers`, add:
+
+```STS\Tunneler\TunnelerServiceProvider::class,```
+
+### Register the Provider (version 5.4 and earlier):
 
 For Lumen services, add:
 


### PR DESCRIPTION
Updating the provider registration instructions for Laravel 5.8. This method needs testing/verification — omitting either provider line resulted in an "Uncaught ReflectionException" error.