### PR TITLE
multiple fixes, probably warrants a 2.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,6 @@ We do not support version <=5.1.
 composer require stechstudio/laravel-ssh-tunnel
 ```
 
-### Register the Provider (Laravel version 5.8):
-
-Inside the `config/app.php` file under `Package Service Providers`, add:
-
-```STS\Tunneler\TunnelerServiceProvider::class,```
-
-And under `Application Service Providers`, add:
-
-```STS\Tunneler\TunnelerServiceProvider::class,```
-
 ### Register the Provider (version 5.4 and earlier):
 
 For Lumen services, add:

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ TUNNELER_PORT=sshport
 
 ; How long to wait, in microseconds, before testing to see if the tunnel is created.
 ; Depending on your network speeds you will want to modify the default of .5 seconds
-TUNNELER_CONN_WAIT=500000
+TUNNELER_CONN_WAIT=1000000
 
 ; How often it is checked if the tunnel is created. Useful if the tunnel creation is sometimes slow, 
 ; and you want to minimize waiting times 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "illuminate/support": "^5.0|^6.0"
+        "illuminate/support": "^5.5|^6.0"
     },
     "extra": {
         "laravel": {

--- a/config/tunneler.php
+++ b/config/tunneler.php
@@ -18,7 +18,7 @@ return [
     'user' => env('TUNNELER_USER'),
     'hostname' => env('TUNNELER_HOSTNAME'),
     'port' => env('TUNNELER_PORT'),
-    'wait' => env('TUNNELER_CONN_WAIT', '500000'),
+    'wait' => env('TUNNELER_CONN_WAIT', '1000000'),
     'tries' => env('TUNNELER_CONN_TRIES', 1),
 
     'on_boot' => filter_var(env('TUNNELER_ON_BOOT', false), FILTER_VALIDATE_BOOLEAN),

--- a/src/Console/TunnelerCommand.php
+++ b/src/Console/TunnelerCommand.php
@@ -19,7 +19,7 @@ class TunnelerCommand extends Command {
 
     public function handle(){
         try {
-            $result = dispatch(new CreateTunnel());
+            $result = dispatch_now(new CreateTunnel());
         }catch (\ErrorException $e){
             $this->error($e->getMessage());
             return 1;

--- a/src/Jobs/CreateTunnel.php
+++ b/src/Jobs/CreateTunnel.php
@@ -24,7 +24,7 @@ class CreateTunnel
     public function __construct()
     {
 
-        $this->ncCommand = sprintf('%s -z %s %d  > /dev/null 2>&1',
+        $this->ncCommand = sprintf('%s -vz %s %d  > /dev/null 2>&1',
             config('tunneler.nc_path'),
             config('tunneler.local_address'),
             config('tunneler.local_port')


### PR DESCRIPTION
I include here a few fixes without which I was getting constant errors on L5.8 running on Ubuntu 18.04

One of the fixes, related to `dispatch_now` does break compatibility with versions prior to Laravel 5.5, so it might be best to release a 2.0 release and mention that this is only compatible with 5.5 and up

Everything works well now that I'm using my fork