### PR TITLE
Add tunneler:reset Command

### DIFF
--- a/src/Console/TunnelerReset.php
+++ b/src/Console/TunnelerReset.php
@@ -38,6 +38,8 @@ class TunnelerReset extends Command
     public function handle()
     {
         $tunnel = new CreateTunnel();
-        return 0;
+        $tunnel->destoryTunnel();
+
+        \Artisan::call('tunneler:activate');
     }
 }

--- a/src/Console/TunnelerReset.php
+++ b/src/Console/TunnelerReset.php
@@ -1,0 +1,43 @@
+<?php
+namespace STS\Tunneler\Console;
+
+use Illuminate\Console\Command;
+use STS\Tunneler\Jobs\CreateTunnel;
+
+class TunnelerReset extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'tunneler:reset';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Destroy and reconnect the SSH tunnel';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $tunnel = new CreateTunnel();
+        return 0;
+    }
+}

--- a/src/Jobs/CreateTunnel.php
+++ b/src/Jobs/CreateTunnel.php
@@ -58,13 +58,13 @@ class CreateTunnel
         }
 
         $this->createTunnel();
-        
+
         $tries = config('tunneler.tries');
         for ($i = 0; $i < $tries; $i++) {
             if ($this->verifyTunnel()) {
                 return 2;
             }
-            
+
             // Wait a bit until next iteration
             usleep(config('tunneler.wait'));
         }
@@ -99,6 +99,14 @@ class CreateTunnel
         }
 
         return $this->runCommand($this->ncCommand);
+    }
+
+    /*
+     * Use pkill to kill the SSH tunnel
+     */
+
+    public function destoryTunnel(){
+        return $this->runCommand('pkill -f "'.$this->sshCommand.'"');
     }
 
     /**

--- a/src/Jobs/CreateTunnel.php
+++ b/src/Jobs/CreateTunnel.php
@@ -106,7 +106,8 @@ class CreateTunnel
      */
 
     public function destoryTunnel(){
-        return $this->runCommand('pkill -f "'.$this->sshCommand.'"');
+        $ssh_command = preg_replace('/[\s]{2}[\s]*/',' ',$this->sshCommand);
+        return $this->runCommand('pkill -f "'.$ssh_command.'"');
     }
 
     /**

--- a/src/TunnelerServiceProvider.php
+++ b/src/TunnelerServiceProvider.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\ServiceProvider;
 use STS\Tunneler\Console\TunnelerCommand;
+use STS\Tunneler\Console\TunnelerReset;
 use STS\Tunneler\Jobs\CreateTunnel;
 
 
@@ -50,6 +51,14 @@ class TunnelerServiceProvider extends ServiceProvider{
         );
 
         $this->commands('command.tunneler.activate');
+
+        $this->app->singleton('command.tunneler.reset',
+            function ($app) {
+                return new TunnelerReset();
+            }
+        );
+
+        $this->commands('command.tunneler.reset');
     }
 
     /**


### PR DESCRIPTION
This `tunneler:reset` command is useful if you have long running processing and want to periodically reset the ssh tunnel to make sure it's still fresh.  

nc appears to show the connection as valid even though it is actually stalled.

This command uses pkill to kill the ssh tunnel then will re-activate the tunnel.